### PR TITLE
Fix inconsistencies in API naming and formatting + add links

### DIFF
--- a/doc/activities/WP5.3-Development-of-connectors-by-WP-partners-starting-from-specifiactions-for-reference-connector/WP5.3.1 - Management of development.md
+++ b/doc/activities/WP5.3-Development-of-connectors-by-WP-partners-starting-from-specifiactions-for-reference-connector/WP5.3.1 - Management of development.md
@@ -3,28 +3,27 @@
 This table shows which partner who had developed which API and are ready for interchangeing information. The API:s are devided in the same matter as chapter specification on http://developers.erasmuswithoutpaper.eu/
 
 
-| API/Partner                                 | Umeå  | Gent  | Porto |  SOP  | KION  | Sigma | Oslo  | Warsaw | Others|
-| ------------------------------------------- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ------ | ----- |
-| **DECEMBER 2016**                           |       |       |       |       |       |       |       |        |       |
-| In Registry                                 |:link: |:link: |:soon: |:link: |:soon: |:link: |:link: |:link:  |   -   |
-| Discovery                                   |:star: |:star: |:soon: |:star: |:soon: |:star: |:star: |:star:  |   -   |
-| Echo                                        |:star: |:star: |:soon: |:star: |:soon: |:star: |:star: |:star:  |   -   |
-| **March 2017**                              |       |       |       |       |       |       |       |        |       | 
-| Institutions API                            |:star: |:star: |   -   |:star: |   -   |:soon: |:star: |:star:  |   -   |
-| Organizational units                        |:star: |:star: |   -   |   -   |   -   |   -   |:star: |:star:  |   -   |
-| **April 2017**                              |       |       |       |       |       |       |       |        |       | 
-| Nominations API                             |   -   |   -   |   -   |   -   |   -   |   -   |   -   |:soon:  |   -   |
-| **May 2017**                                |       |       |       |       |       |       |       |        |       | 
-| Learning Agreement API                      |   -   |   -   |   -   |   -   |   -   |   -   |   -   |   -    |   -   |
-| **June 2017**                               |       |       |       |       |       |       |       |        |       | 
-| Transcript of Record                        |   -   |   -   |   -   |   -   |   -   |   -   |   -   |   -    |   -   |
-| **May - June 2017**                         |       |       |       |       |       |       |       |        |       | 
-| Courses                                     |:star: |   -   |   -   |   -   |   -   |   -   |:soon: |   -    |   -   |
-| **July - September 2017**                   |       |       |       |       |       |       |       |        |       | 
-| Testing and improving                       |   -   |   -   |   -   |   -   |   -   |   -   |   -   |   -    |   -   |
-| IIA                                         |:star: |   -   |   -   |   -   |   -   |   -   |:star: |:star:  |   -   |
-| Mobilities                                  |:star: |   -   |   -   |   -   |   -   |   -   |:soon: |:star:  |   -   |
-| Simple course Replication (optional)        |   -   |   -   |   -   |   -   |   -   |   -   |   -   |   -    |   -   |
+| API/Partner                                                        | Umeå   | Gent   | Porto  | SOP    | KION   | Sigma  | Oslo   | Warsaw | Others |
+|--------------------------------------------------------------------|:------:|:------:|:------:|:------:|:------:|:------:|:------:|:------:|:------:|
+| **DECEMBER 2016**                                                  |        |        |        |        |        |        |        |        |        |
+| In Registry                                                        | :link: | :link: | :soon: | :link: | :soon: | :link: | :link: | :link: | -      |
+| [Discovery API][discovery-api]                                     | :star: | :star: | :soon: | :star: | :soon: | :star: | :star: | :star: | -      |
+| [Echo API][echo-api]                                               | :star: | :star: | :soon: | :star: | :soon: | :star: | :star: | :star: | -      |
+| **MARCH 2017**                                                     |        |        |        |        |        |        |        |        |        |
+| [Institutions API][institutions-api]                               | :star: | :star: | -      | :star: | -      | :soon: | :star: | :star: | -      |
+| [Organizational Units API][ounits-api]                             | :star: | :star: | -      | -      | -      | -      | :star: | :star: | -      |
+| **APRIL 2017**                                                     |        |        |        |        |        |        |        |        |        |
+| Nominations part of [Outgoing Mobilities API][mobilities-api]      | -      | -      | -      | -      | -      | -      | -      | :soon: | -      |
+| **MAY 2017**                                                       |        |        |        |        |        |        |        |        |        |
+| The rest of [Outgoing Mobilities API][mobilities-api]              | -      | -      | -      | -      | -      | -      | -      | -      | -      |
+| **JUNE 2017**                                                      |        |        |        |        |        |        |        |        |        |
+| [Transcripts of Records API][tors-api]                             | -      | -      | -      | -      | -      | -      | -      | -      | -      |
+| **MAY - JUNE 2017**                                                |        |        |        |        |        |        |        |        |        |
+| [Courses API][courses-api]                                         | :star: | -      | -      | -      | -      | -      | :soon: | -      | -      |
+| **JULY - SEPTEMBER 2017**                                          |        |        |        |        |        |        |        |        |        |
+| Testing and improving                                              | -      | -      | -      | -      | -      | -      | -      | -      | -      |
+| [IIAs API][iias-api]                                               | :star: | -      | -      | -      | -      | -      | :star: | :star: | -      |
+| [Simple Course Replication API][course-replication-api] (optional) | -      | -      | -      | -      | -      | -      | -      | -      | -      |
 
 | Delivery deadlines 	| Type of activities                                       	|
 |--------------------	|----------------------------------------------------------	|
@@ -41,3 +40,18 @@ This table shows which partner who had developed which API and are ready for int
 * "-" means that the development is **not started** yet
 
 * :link: in section **In Registry** means that test server is public and added to the registry 
+
+
+<!-- API links -->
+[discovery-api]: https://github.com/erasmus-without-paper/ewp-specs-api-discovery
+[echo-api]: https://github.com/erasmus-without-paper/ewp-specs-api-echo
+[registry-api]: https://github.com/erasmus-without-paper/ewp-specs-api-registry
+[institutions-api]: https://github.com/erasmus-without-paper/ewp-specs-api-institutions
+[ounits-api]: https://github.com/erasmus-without-paper/ewp-specs-api-ounits
+[courses-api]: https://github.com/erasmus-without-paper/ewp-specs-api-courses
+[course-replication-api]: https://github.com/erasmus-without-paper/ewp-specs-api-course-replication
+[iias-api]: https://github.com/erasmus-without-paper/ewp-specs-api-iias
+[iia-cnr-api]: https://github.com/erasmus-without-paper/ewp-specs-api-iia-cnr
+[mobilities-api]: https://github.com/erasmus-without-paper/ewp-specs-api-mobilities
+[mobility-cnr-api]: https://github.com/erasmus-without-paper/ewp-specs-api-mobility-cnr
+[tors-api]: https://github.com/erasmus-without-paper/ewp-specs-api-tors


### PR DESCRIPTION
Some names are confusing. For example, I get questions such as "What is the Nominations API?". This commit fixes this.